### PR TITLE
Fix value prop usage in NumericFormat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plain-dapp-update",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plain-dapp-update",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "dependencies": {
         "@blockshake/defly-connect": "^1.1.5",
         "@curvefi/api": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plain-dapp-update",
   "private": true,
-  "version": "1.18.0",
+  "version": "1.18.1",
   "type": "module",
   "scripts": {
     "dev": "npm run create-version-file && vite",

--- a/src/components/organisms/swapLine/SwapLine.jsx
+++ b/src/components/organisms/swapLine/SwapLine.jsx
@@ -1,13 +1,15 @@
-import React, { useState, useEffect, useMemo } from 'react'
-import styled from 'styled-components'
 import PropTypes from 'prop-types'
+import React, { useState, useEffect, useMemo } from 'react'
 import { Row, Col } from 'react-bootstrap'
-import { capitalizeAllLettersExceptFirst } from '../../../utils/capitalize'
-import { NumericFormat } from 'react-number-format'
-import AssetInfo from '../assetInfo/AssetInfo'
-import Icon from '../../atoms/icon/Icon'
-import { getDecimalSeparator, getThousandSeparator } from '../../../utils/amount-utils'
 import Skeleton from 'react-loading-skeleton'
+import { NumericFormat } from 'react-number-format'
+import styled from 'styled-components'
+
+import { getDecimalSeparator, getThousandSeparator } from '../../../utils/amount-utils'
+import { capitalizeAllLettersExceptFirst } from '../../../utils/capitalize'
+import Icon from '../../atoms/icon/Icon'
+import AssetInfo from '../assetInfo/AssetInfo'
+
 import 'react-loading-skeleton/dist/skeleton.css'
 
 const SwapLineContainer = styled.div`
@@ -275,7 +277,7 @@ const SwapLine = ({
                 disabled={disableInput}
                 onValueChange={(_e, _source) => onChangeAmount(_e.value.toString().replace(',', '.'), _source)}
                 prefix={prefix}
-                value={amount !== '' ? +amount : amount}
+                value={amount}
                 allowedDecimalSeparators={[',', '.']}
                 decimalSeparator={getDecimalSeparator()}
                 thousandSeparator={getThousandSeparator()}


### PR DESCRIPTION
The usage of + sign returns the numerical representation of an object.
With some strings, this introduces some unwanted rounding.

For example:
```js
const val = "2812.4283046805994"
console.info(+val)
# 2812.4283046805995
```

Plus, `NumericFormat` expects value to be of type string, so it's not necessary to cast into number.

This PR just revises how value is passed to `NumericFormat`.